### PR TITLE
remove rework peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "dependencies": {
     "debug": "*"
   },
-  "peerDependencies": {
-    "rework": ">= 0.15.0"
-  },
   "devDependencies": {
     "rework": ">= 0.15.0"
   },


### PR DESCRIPTION
peerDependencies cause more issues than they are useful. in my particular case, it breaks npm shrinkwrap.
