### PR TITLE
Kill the 0.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"


### PR DESCRIPTION
The library no longer works with 0.8 and it's making all the tests look like they're failing.
